### PR TITLE
Adds create content type, create content by role, and restricted cont…

### DIFF
--- a/CHEATSHEET.md
+++ b/CHEATSHEET.md
@@ -160,3 +160,45 @@ cy.get('#edit-revision-log-0-value').type('This is a revision log message.');
 cy.get('#edit-submit').click();
 cy.get('#revision-log-message').should('contain', 'This is a revision log message');
 ```
+
+### Create a Content Type
+
+```markdown
+// Visit any content type creation page.
+cy.visit('/node/add/event')
+// Set title, body, and image.
+const nodeTitle = "TEST CONTENT - " +  randCompanyName();
+cy.get("#edit-title-wrapper").type(nodeTitle);
+const nodeBody = randLines();
+cy.ckeditorType('#edit-body-wrapper', nodeBody);
+cy.mediaLibrarySelect('#field_image-media-library-wrapper', 'image-sample_01.png', 'image')
+cy.get("#edit-submit--2--gin-edit-form").click();
+// Validate.
+cy.get('main').should('contain', nodeTitle);
+cy.get('main').should('contain', nodeBody);
+```
+
+### Test a user/user role's ability to create multiple content types
+
+```markdown
+// Create support commands for each content type and run in series with user role.
+cy.login('cypress', 'cypress');
+cy.createDocument();
+cy.createEvent();
+cy.createPage();
+cy.createPerson();
+cy.logout();
+```
+
+### Test if a user/user role can't create content
+
+```markdown
+// User should hit a 403 error on a restricted node/add.
+cy.request({
+  url: '/node/add/event',
+  followRedirect: false,
+  failOnStatusCode: false
+}).then((resp) => {
+    expect(resp.status).to.eq(403)
+})
+```


### PR DESCRIPTION

## Description
Related Drupal Issue(s): [Add to Cheatsheet: Create support command for content type creation](https://www.drupal.org/project/shrubs/issues/3402917)
Related Drupal Issue(s): [Add to Cheatsheet: Create support command to verify user can't create content](https://www.drupal.org/project/shrubs/issues/3402920#comment-15340812)
Related Drupal Issue(s): [Add to Cheatsheet: Create a test that tests a user/user role's ability to create multiple content types](https://www.drupal.org/project/shrubs/issues/3402919#comment-15340813)

**This PR adds 3 items to the cheatsheet**
- Content type creation
- User role content type/types creation
- User role content type restriction