### PR TITLE
Adds delete node code snippets to the cheatsheet.md

### DIFF
--- a/CHEATSHEET.md
+++ b/CHEATSHEET.md
@@ -33,6 +33,11 @@
 - Schedule an unpublishing time: [Code Snippet](#schedule-an-unpublishing-time)
 - Write a revision log message: [Code Snippet](#write-a-revision-log-message)
 
+### Deleting a Node
+
+- Delete a node from node page while logged in: [Code Snippet](#delete-a-piece-of-content-from-the-node-page)
+- Delete a node from the node edit page while logged in: [Code Snippet](#delete-a-piece-of-content-from-the-node-edit-page)
+
 ## User Role Testing
 
 The following commands generally best created as support commands.
@@ -203,7 +208,6 @@ cy.request({
 })
 ```
 
-
 ### Test a user/user role's ability to create multiple content types
 
 ```markdown
@@ -214,4 +218,34 @@ cy.createEvent();
 cy.createPage();
 cy.createPerson();
 cy.logout();
+```
+
+### Delete a piece of content from the node page
+
+```markdown
+// Click node Delete button.
+cy.get('.nav-link').contains('Delete').click();
+// Click confirm delete.
+cy.get('.button--danger').click();
+// Validate, we should be on the home page.
+cy.get('h1').should('contain', 'Hamilton Educational Website');
+```
+
+### Delete a piece of content from the node edit page
+
+```markdown
+// Visit the node edit page.
+cy.visit('node/[nodeID]/edit?destination=/admin/content')
+// Click node Delete button.
+cy.get('#edit-delete--2').click();
+// Create a unique variable name for the ajax listener.  Cypress does not like it being reused.
+const deleteModalAjax = 'deleteModalAjax' + '#edit-delete--2' + Math.random();
+cy.intercept('POST', '/media-library**').as(deleteModalAjax)
+// Get the delete modal and delete the node.
+cy.get('.ui-dialog-buttonpane').within(($modal) => {
+  // Get the delete button in the modal and click.
+  cy.get('.button--danger').contains('Delete', { matchCase: false }).click();
+})
+// Validate, we should be on the admin/content page.
+cy.get('h1').should('contain', 'Content');
 ```

--- a/CHEATSHEET.md
+++ b/CHEATSHEET.md
@@ -9,6 +9,8 @@
 
 ## Content Type Testing
 
+Check if you are on the front or home page: [Code Snippet](#check-if-you-are-on-the-front-or-home-page)
+
 ### Creating a Node
 
 - Go to a node add form: `cy.visit('/node/add'); // Replace with the actual URL of your content`

--- a/CHEATSHEET.md
+++ b/CHEATSHEET.md
@@ -9,7 +9,7 @@
 
 ## Content Type Testing
 
-Check if you are on the front or home page: [Code Snippet](#check-if-you-are-on-the-front-or-home-page)
+- Check if you are on the front or home page: [Code Snippet](#check-if-you-are-on-the-front-or-home-page)
 
 ### Creating a Node
 

--- a/CHEATSHEET.md
+++ b/CHEATSHEET.md
@@ -223,12 +223,17 @@ cy.logout();
 ### Delete a piece of content from the node page
 
 ```markdown
-// Click node Delete button.
-cy.get('.nav-link').contains('Delete').click();
-// Click confirm delete.
-cy.get('.button--danger').click();
-// Validate, we should be on the home page.
-cy.get('h1').should('contain', 'Hamilton Educational Website');
+Cypress.Commands.add('deleteContentFromNode', (nodeID) => {
+  let nodePath = 'node/' + nodeID;
+  // Visit a node
+  cy.visit(nodePath);
+  // Click node Delete button.
+  cy.get('.nav-link').contains('Delete').click();
+  // Click confirm delete.
+  cy.get('#edit-submit').contains('Delete').click();
+  // Validate, we should be on the home page.
+  cy.location('pathname').should('eq', '/');
+})
 ```
 
 ### Delete a piece of content from the node edit page
@@ -248,4 +253,14 @@ cy.get('.ui-dialog-buttonpane').within(($modal) => {
 })
 // Validate, we should be on the admin/content page.
 cy.get('h1').should('contain', 'Content');
+```
+
+### Check if you are on the front or home page
+
+```markdown
+// Visit the home page
+// Update this URL based on your application's structure
+cy.visit('/');
+// Check if the current URL is the home page
+cy.location('pathname').should('eq', '/');
 ```


### PR DESCRIPTION
## Description
Related Drupal Issue(s): [Add to Cheatsheet: User/User Role can delete a piece of content](https://www.drupal.org/project/shrubs/issues/3402918)

**This PR adds 2 items to the cheatsheet**
- Delete content from node page
- Delete content from node edit page