### PR TITLE
Logout by clearing cookies

### DIFF
--- a/login.js
+++ b/login.js
@@ -3,7 +3,7 @@
 // cy.login('username', 'password'); // login as a specific user.
 
 Cypress.Commands.add('login', (usernameParam = '', password = '') => {
-    cy.visit('/user/logout')
+    cy.logout()
     cy.visit('/user/login')
     let username = '';
     let default_user = false;

--- a/logout.js
+++ b/logout.js
@@ -2,5 +2,5 @@
 // cy.logout();  // Logs out user.
 
 Cypress.Commands.add('logout', () => {
-  cy.visit('/user/logout')
+  cy.clearAllCookies();
 })


### PR DESCRIPTION
`/user/logout` path may not be available in all Drupal installs so update the logout command to clear the browser cookies.   I.e. A site has SSO enable and that redirects to the SSO provider 

Updates the login command to use the logout command and not `/user/logout`
