### PR TITLE
Adds switching to horizontal tab in admin

### DIFF
--- a/CHEATSHEET.md
+++ b/CHEATSHEET.md
@@ -34,6 +34,7 @@
 - Schedule a publishing time: [Code Snippet](#schedule-a-publishing-time)
 - Schedule an unpublishing time: [Code Snippet](#schedule-an-unpublishing-time)
 - Write a revision log message: [Code Snippet](#write-a-revision-log-message)
+- Open a field group tab in the admin: [Code Snippet](#open-a-field-group-tab-in-the-admin)
 
 ### Deleting a Node
 
@@ -178,6 +179,13 @@ cy.get('#edit-revision-information').click();
 cy.get('#edit-revision-log-0-value').type('This is a revision log message.');
 cy.get('#edit-submit').click();
 cy.get('#revision-log-message').should('contain', 'This is a revision log message');
+```
+
+### Open a field group tab in the admin
+```markdown
+cy.visit('/node/[nodeID]/edit');
+// Switch to the horizontal content tab.
+cy.get('#node-page-edit-form').contains('Content').click()
 ```
 
 ### Create a Content Type


### PR DESCRIPTION
## Description
Teamwork Ticket(s): [Add to Cheatsheet: Opening Field groups in admin forms](https://www.drupal.org/project/shrubs/issues/3397525)

> As a developer, I need to add an example to the cheatsheet.md on how to switch to a horizontal tab field in the admin/edit form.