### PR TITLE
mediaLibraryAdd incorrectly assumes the image field is field_media_image

### DIFF
--- a/mediaLibraryAdd.js
+++ b/mediaLibraryAdd.js
@@ -40,7 +40,7 @@ Cypress.Commands.add("mediaLibraryAdd", (selector, fileName, type="") => {
 
     // Basic check if the file is an image so we know if we have to add some alt tags.
     if (fileName.includes(".png") || fileName.includes(".jpg")) {
-      cy.get('input[name="media[0][fields][field_media_image][0][alt]"]').type('alt text');
+      cy.get('.media-library-add-form').contains('Alternative text').next().type('alt text');
     }
 
     // Select the uploaded file.


### PR DESCRIPTION
https://www.drupal.org/project/shrubs/issues/3419010

Image media entities can have image fields named something different besides field_media_image.

The command should be less specific.

Convo from Slack:

Russell:

> 
>     So the mediaLibraryAdd shrub doesn't work on this recipe/starter unless I update the line
>     `cy.get('input[name="media[0][fields][field_media_image][0][alt]"]').type('alt text');`
>     to
>     cy.get('input[name="media[0][fields][sa_media_image][0][alt]"]').type('alt text');
>     Changing `field_media_image` to `sa_media_image`
>     Is there any way we can get around this without having to directly edit the shrub file in the future?

yada yada yada

Paul:

>     so... here's what i think could work.
>     `cy.get('.media-library-add-form').contains('Alternative text').next().type('alt text')`