### PR TITLE
Use session cookie to check if the user is logged in

### DIFF
--- a/login.js
+++ b/login.js
@@ -27,9 +27,9 @@ Cypress.Commands.add('login', (usernameParam = '', password = '') => {
   cy.wait(500); // Wait for the UI to catch up.
 
   // Check user session cookie is set after logging in.
-  cy.getCookies()
-    .should("have.length", 1)
-    .then((cookies) => {
-      expect(cookies[0].name).to.include("SESS");
-    });
+  cy.getCookies().then((cookies) => {
+    // Search for cookie.name and value contains SESS.
+    const sessionCookie = cookies.find((cookie) => cookie.name.includes("SESS"));
+    expect(sessionCookie).to.exist;
+  });
 })

--- a/login.js
+++ b/login.js
@@ -3,32 +3,33 @@
 // cy.login('username', 'password'); // login as a specific user.
 
 Cypress.Commands.add('login', (usernameParam = '', password = '') => {
-    cy.logout()
-    cy.visit('/user/login')
-    let username = '';
-    let default_user = false;
-    if (usernameParam === '' && password === '') {
-      username = 'cypress';
-      default_user = true;
-    }
-    else {
-      username = usernameParam;
-    }
+  cy.logout();
+  cy.visit("/user/login");
+  let username = "";
+  let default_user = false;
+  if (usernameParam === "" && password === "") {
+    username = "cypress";
+    default_user = true;
+  } else {
+    username = usernameParam;
+  }
 
-    if (default_user) {
-        cy.get('form.user-login-form #edit-name').type(username);
-        cy.get('form.user-login-form #edit-pass').type('cypress');
-    }
-    else {
-        cy.get('form.user-login-form #edit-name').type(username);
-        cy.get('form.user-login-form #edit-pass').type(password);
-    }
+  if (default_user) {
+    cy.get("form.user-login-form #edit-name").type(username);
+    cy.get("form.user-login-form #edit-pass").type("cypress");
+  } else {
+    cy.get("form.user-login-form #edit-name").type(username);
+    cy.get("form.user-login-form #edit-pass").type(password);
+  }
 
-    // Login.
-    cy.get('form.user-login-form .form-submit').click();
-    cy.wait(500) // Wait for the UI to catch up.
+  // Login.
+  cy.get("form.user-login-form .form-submit").click();
+  cy.wait(500); // Wait for the UI to catch up.
 
-    // Check user page loads.
-    cy.get('main').contains(username)
-    cy.get('main').contains('Member for')
+  // Check user session cookie is set after logging in.
+  cy.getCookies()
+    .should("have.length", 1)
+    .then((cookies) => {
+      expect(cookies[0].name).to.include("SESS");
+    });
 })


### PR DESCRIPTION
## Description
Drupal issue: https://www.drupal.org/project/shrubs/issues/3485946

## Problem/Motivation
The login.js command assumes that the user login page will contain the strings "username" and "Member" in the DOM inside the HTML element. However, this is not always the case across all projects, as it depends on how the main frontend theme is set up.

## Steps to reproduce

- Remove the username from the user page at /user/[user_name]
- Run the shrubs login command
- Proposed resolution
- Instead of checking for the username in the DOM, let's check the current domain cookies for a name and ensure it contains "SESS".


## Steps to Validate
Validate the login cmd works as expected.

## Deploy Notes
N/A