### PR TITLE
tw29821365 - adds background option to drush command WIP

### DIFF
--- a/drush.js
+++ b/drush.js
@@ -6,25 +6,31 @@ Cypress.Commands.add('drush', (command, options = {}) => {
 
   let exec_command = '';
 
+  const isBackground = options.background === true;
+  const suffix = isBackground ? ' &' : '';
+
   if (Cypress.env('DRUSH_IS_DOCKSAL')) {
-    exec_command = 'fin drush '  + command;
+    exec_command = 'fin drush '  + command + suffix;
   }
 
   if (Cypress.env('DRUSH_IS_LANDO')) {
-    exec_command = 'lando drush '  + command;
+    exec_command = 'lando drush '  + command + suffix;
   }
 
   if (Cypress.env('DRUSH_IS_DDEV')) {
-    exec_command = 'ddev drush '  + command;
+    exec_command = 'ddev drush '  + command + suffix;
   }
 
   // In the format of PANTHEON_SITE_ID.ENVIRONMENT_ID
   if(Cypress.env('DRUSH_IS_PANTHEON')) {
     // Passing URI as well because drush will return HTTP links by default and not HTTPS which can cause tests to fail.
-    exec_command = 'ssh -T ' + Cypress.env('DRUSH_IS_PANTHEON') + '@appserver.' + Cypress.env('DRUSH_IS_PANTHEON') + '.drush.in -p 2222 -o "StrictHostKeyChecking=no" -o "AddressFamily inet" "drush --uri=' + Cypress.config('baseUrl') +  ' ' + command + '"';
+    exec_command = 'ssh -T ' + Cypress.env('DRUSH_IS_PANTHEON') +
+      '@appserver.' + Cypress.env('DRUSH_IS_PANTHEON') + '.drush.in -p 2222 ' +
+      '-o "StrictHostKeyChecking=no" -o "AddressFamily inet" ' +
+      `"drush --uri=${Cypress.env('CYPRESS_BASE_URL')} ${command}${suffix}"`;
   }
 
-  cy.exec(exec_command, options).then((result) => {
+  cy.exec(exec_command, { ...options, failOnNonZeroExit: false }).then((result) => {
     cy.log(result.stdout);
     cy.wrap(result.stdout).as('drushOutput');
   })


### PR DESCRIPTION
## Description
Teamwork Ticket(s): https://kanopi.teamwork.com/app/tasks/29821365 (for Humane World)

I wrote a [cypress test](https://github.com/kanopi/humane-world/blob/main/tests/cypress/cypress/e2e/reindex-if-needed.cy.js) that checks for certain search results, and if it finds none, it clears and reindexes search on the multidev. It essentially works, but because it takes so long to reindex, the test is almost always "failed" even though I can see things are working as I intended.

I asked AI to help me with running the reindex drush command in the background. It advised changing the shrubs drush command as I have done in this PR.

I have tested this in docksal and it works as intended.

I am in the process of testing it on the multidev by pointing composer to this branch.

## Acceptance Criteria
* A list describing how the feature should behave
* e.g. Clicking outside a modal will close it
* e.g. Clicking on a new accordion tab will not close open tabs

## Assumptions
* A list of things the code reviewer or project manager should know
* e.g. There is a known Javascript error in the console.log
* e.g. On any `multidev`, the popup plugin breaks.

## Steps to Validate
1. A list of steps to validate
1. Include direct links to test sites (specific nodes, admin screens, etc)
1. Be explicit

## Affected URL
[link_to_relevant_multidev_or_test_site](insert_link_here)

## Deploy Notes
_Notes regarding deployment of the contained body of work. These should note any
new dependencies, new scripts, etc. This should also include work that needs to be 
accomplished post-launch like enabling a plugin._
